### PR TITLE
Fix caption_text, alt_text in the template. Allow empty tag_type.

### DIFF
--- a/cmsplugin_svg/models.py
+++ b/cmsplugin_svg/models.py
@@ -22,6 +22,7 @@ class SvgImage(CMSPlugin):
     """
 
     TAG_TYPE_CHOICES = (
+        ('', ''),
         ('figure', 'figure'),
         # ('div', 'div'),
     )
@@ -56,7 +57,8 @@ class SvgImage(CMSPlugin):
         verbose_name=_('tag Type'),
         max_length=50,
         choices=TAG_TYPE_CHOICES,
-        default=TAG_TYPE_CHOICES[0][0],
+        null=True,
+        blank=True,
     )
 
     svg_image = FilerFileField(

--- a/cmsplugin_svg/templates/cmsplugin_svg/plugin.html
+++ b/cmsplugin_svg/templates/cmsplugin_svg/plugin.html
@@ -1,7 +1,12 @@
 {% load cms_tags %}
 {% spaceless %}
-<{{ instance.tag_type }} {% if instance.id_name %}id="{{ instance.id_name }}"{% endif %} class="{% if instance.additional_class_names %}{{ instance.get_additional_class_names }}{% endif %}" style="{% if instance.alignment %}text-align: {{ instance.alignment }};{% endif %}">
-    <img src="{{ instance.svg_image.url }}" alt="{% if instance.alt %}{{ instance.alt }}{% endif %}"{% if instance.width %} width="{{ instance.width }}"{% endif %}{% if instance.height %} height="{{ instance.height }}"{% endif %} />
-    {% if instance.caption_text %}<figcaption>{{ caption_text }}</figcaption>{% endif %}
-</{{ instance.tag_type }}>
+{% if instance.tag_type %}
+    <{{ instance.tag_type }} {% if instance.id_name %}id="{{ instance.id_name }}"{% endif %} class="{% if instance.additional_class_names %}{{ instance.get_additional_class_names }}{% endif %}" style="{% if instance.alignment %}text-align: {{ instance.alignment }};{% endif %}">
+        <img src="{{ instance.svg_image.url }}" alt="{% if instance.alt_text %}{{ instance.alt_text }}{% endif %}"{% if instance.width %} width="{{ instance.width }}"{% endif %}{% if instance.height %} height="{{ instance.height }}"{% endif %} />
+        {% if instance.caption_text %}<figcaption>{{ instance.caption_text }}</figcaption>{% endif %}
+    </{{ instance.tag_type }}>
+{% else %}
+    <img src="{{ instance.svg_image.url }}" alt="{% if instance.alt_text %}{{ instance.alt_text }}{% endif %}"{% if instance.width %} width="{{ instance.width }}"{% endif %}{% if instance.height %} height="{{ instance.height }}"{% endif %} />
+    {% if instance.caption_text %}<figcaption>{{ instance.caption_text }}</figcaption>{% endif %}
+{% endif %}
 {% endspaceless %}


### PR DESCRIPTION
Fix not working texts `alt` and `caption`. Allow placing `img` without wrapping it into the `figure`.